### PR TITLE
Fix climbing up hierarchy

### DIFF
--- a/Settings.cs
+++ b/Settings.cs
@@ -124,17 +124,15 @@ namespace RunCliCommandOnSave {
     }
 
     private string LocateSettings(string startingPath) {
-      var cfgFile = new FileInfo(Path.Combine(startingPath, kSettingsFileName));
       var dir = new DirectoryInfo(startingPath);
-      while (!cfgFile.Exists && dir.Parent != null) {
-        var configs = dir.GetFiles(kSettingsFileName);
-        if (configs.Length > 0) {
-          cfgFile = configs[0];
-          break;
+      while (dir != null) {
+        var cfgFile = Path.Combine(dir.FullName, kSettingsFileName);
+        if (File.Exists(cfgFile)) {
+          return cfgFile;
         }
         dir = dir.Parent;
       }
-      return cfgFile.Exists ? cfgFile.FullName : null;
+      return null;
     }
 
     [DllImport("kernel32")]


### PR DESCRIPTION
When the settings file was located at the root of a disk, the "climbing up" the hierarchy would stop too soon, i.e. as soon as the parent was `null` but before having tested at that location. This fixes it.

Discovered in a SUBST directory->drive letter