### PR TITLE
Add a GitHub workflow to build and create a download artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,10 @@ name: Build
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,53 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        configuration: [Debug,Release]
+    env:
+      Solution_name: run_cli_command_on_save.sln
+    steps:
+      # Checkout repository
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Install and setup environment
+      - name: Install .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1
+
+      # Restore dependencies and build
+      - name: Restore
+        run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
+        env:
+          Configuration: ${{ matrix.configuration }}
+      - name: Build
+        run: msbuild $env:Solution_Name /t:Build /p:Configuration=$env:Configuration
+        env:
+          Configuration: ${{ matrix.configuration }}
+
+      # Publish as GH artifact
+      - name: Repository Name
+        id: name
+        shell: bash
+        run: |
+          printf 'value=%s\n' "$(basename "${{ github.repository }}")" >> "$GITHUB_OUTPUT"
+      - name: Publish
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.name.outputs.value }}-${{ matrix.configuration }}.vsix
+          path: ${{ github.workspace }}/bin/${{ matrix.configuration }}/run_cli_command_on_save.vsix


### PR DESCRIPTION
This adds a GitHub workflow that will automatically build the VSIX extension whenever changes are taken into the `main` branch (manual trigger is also supported). At every build, a downloadable artifact is made available.

Note: this is not a GitHub release, nor an artifact pushed to the official marketplace. However, this workflow could be [completed](https://github.com/marketplace/actions/vsix-publisher) in the future to automatically push to the marketplace. This would require storing a token as a secret within the main repository.